### PR TITLE
Convert build to multi-stage build to reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM golang:1.14
+FROM golang:1.14-alpine AS builder
 
+RUN apk add make
 RUN mkdir -p /opt/resource
 RUN mkdir -p /opt/code/bin
 
@@ -12,3 +13,7 @@ ADD ./ /opt/code/
 RUN make compile
 
 RUN cp /opt/code/bin/* /opt/resource/
+
+FROM alpine:3.12
+RUN apk add --update ca-certificates && rm -rf /var/cache/apk/*
+COPY --from=builder /opt/resource /opt/resource/


### PR DESCRIPTION
This will make CI runs much faster as Concourse doesn't have to copy the whole build chain anymore.

The difference:

Before: 909 MB
After: 19.1 MB