### PR TITLE
PP-12218: Add post-merge workflow to tag release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: ci
 
-on: [push]
+on:
+  pull_request:
+  workflow_call:
 
 jobs:
   build-and-test:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,22 @@
+name: Post Merge
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    uses: ./.github/workflows/ci.yml
+
+  tag-release:
+    needs:
+      - tests
+    permissions:
+      contents: write
+    uses: alphagov/pay-ci/.github/workflows/_create-alpha-release-tag.yml@master


### PR DESCRIPTION
Add a post-merge workflow which follows the same tagging convention as other Pay repos adding an alpha_release-XXX tag if the tests pass after merge to main.