### PR TITLE
BAU: Bump Go yaml package to 2.2.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/jarcoal/httpmock v1.0.4
 	github.com/onsi/ginkgo v1.10.2
 	github.com/onsi/gomega v1.7.0
+	gopkg.in/yaml.v2 v2.2.8
 )
 
 require (
@@ -15,5 +16,4 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
-	gopkg.in/yaml.v2 v2.2.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -29,3 +29,5 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkep
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -19,7 +19,7 @@ func TestIntegration(t *testing.T) {
 
 var _ = Describe("Happy path", func() {
 	BeforeSuite(func() {
-		buildCmd := exec.Command("docker-compose", "build")
+		buildCmd := exec.Command("docker", "compose", "build")
 		session, err := gexec.Start(buildCmd, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(session, 60).Should(gexec.Exit(0))
@@ -27,7 +27,7 @@ var _ = Describe("Happy path", func() {
 
 	BeforeEach(func() {
 		upCmd := exec.Command(
-			"docker-compose", "up", "--detach", "--force-recreate",
+			"docker", "compose", "up", "--detach", "--force-recreate",
 		)
 		session, err := gexec.Start(upCmd, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -35,7 +35,7 @@ var _ = Describe("Happy path", func() {
 
 		for i := 1; i <= 10; i++ {
 			curlCmd := exec.Command(
-				"docker-compose", "exec", "-T", "grafana",
+				"docker", "compose", "exec", "-T", "grafana",
 				"curl",
 				"-u", "admin:admin", "-sf", "-m", "10",
 				"http://grafana:3000/api/health",
@@ -61,7 +61,7 @@ var _ = Describe("Happy path", func() {
 
 	It("should create an annotation", func() {
 		beforeCreateCmd := exec.Command(
-			"docker-compose", "exec", "-T", "grafana",
+			"docker", "compose", "exec", "-T", "grafana",
 			"curl",
 			"-u", "admin:admin", "-sf", "-m", "10",
 			"http://grafana:3000/api/annotations",
@@ -74,7 +74,7 @@ var _ = Describe("Happy path", func() {
 		).To(Equal("[]"))
 
 		runCreateOutCmd := exec.Command(
-			"docker-compose", "exec", "-T", "-e", "BUILD_ID=12345", "resource",
+			"docker", "compose", "exec", "-T", "-e", "BUILD_ID=12345", "resource",
 			"/opt/resource/out", "/tmp",
 		)
 		runCreateOutCmd.Stdin = strings.NewReader(`{"source": {"url": "http://grafana:3000", "username": "admin", "password": "admin"}, "params": {}}`)
@@ -92,7 +92,7 @@ var _ = Describe("Happy path", func() {
 `))
 
 		afterCreateCmd := exec.Command(
-			"docker-compose", "exec", "-T", "grafana",
+			"docker", "compose", "exec", "-T", "grafana",
 			"curl",
 			"-u", "admin:admin", "-sf", "-m", "10",
 			"http://grafana:3000/api/annotations",
@@ -116,7 +116,7 @@ var _ = Describe("Happy path", func() {
 		))
 
 		runUpdateOutCmd := exec.Command(
-			"docker-compose", "exec", "-T", "-e", "BUILD_ID=12345", "resource",
+			"docker", "compose", "exec", "-T", "-e", "BUILD_ID=12345", "resource",
 			"/opt/resource/out", "/",
 		)
 		runUpdateOutCmd.Stdin = strings.NewReader(`{"source": {"url": "http://grafana:3000", "username": "admin", "password": "admin"}, "params": {"path": "/tmp"}}`)
@@ -134,7 +134,7 @@ var _ = Describe("Happy path", func() {
 `))
 
 		afterUpdateCmd := exec.Command(
-			"docker-compose", "exec", "-T", "grafana",
+			"docker", "compose", "exec", "-T", "grafana",
 			"curl",
 			"-u", "admin:admin", "-sf", "-m", "10",
 			"http://grafana:3000/api/annotations",
@@ -160,7 +160,7 @@ var _ = Describe("Happy path", func() {
 
 	AfterEach(func() {
 		upCmd := exec.Command(
-			"docker-compose", "down",
+			"docker", "compose", "down",
 		)
 		session, err := gexec.Start(upCmd, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
For some reason Dependabot was struggling to create this update automatically. I also couldn't get the tests to pass unless I moved the dependency to the main `require` section rather than the indirect section.