### PR TITLE
PP-15379 update github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: setup
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # Setup-go v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # 6.4.0
         with:
           go-version: 1.24
 
       - name: checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: deps
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 bin
+
+# IntelliJ gubbins
+.idea
+*.iml
+*.ipr
+*.iws


### PR DESCRIPTION
Github retiring node20. Update actions to a node24 compatible version.